### PR TITLE
[ change ] fields' visibilities to pub

### DIFF
--- a/src/elements/literal.rs
+++ b/src/elements/literal.rs
@@ -18,16 +18,16 @@ pub enum Literal {
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct PlainText {
-    pub(crate) text: String,
-    pub(crate) formatting: Option<FontCommand>,
+    pub text: String,
+    pub formatting: Option<FontCommand>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Symbol {
-    pub(crate) symbol: String,
+    pub symbol: String,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Number {
-    pub(crate) number: String,
+    pub number: String,
 }

--- a/src/elements/special.rs
+++ b/src/elements/special.rs
@@ -33,43 +33,43 @@ pub struct Prod {
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Frac {
-    pub(crate) top: Box<Element>,
-    pub(crate) bottom: Box<Element>,
+    pub top: Box<Element>,
+    pub bottom: Box<Element>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Pow {
-    pub(crate) base: Box<Element>,
-    pub(crate) exp: Box<Element>,
+    pub base: Box<Element>,
+    pub exp: Box<Element>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Sub {
-    pub(crate) base: Box<Element>,
-    pub(crate) lower: Box<Element>,
+    pub base: Box<Element>,
+    pub lower: Box<Element>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Sqrt {
-    pub(crate) inner: Box<Element>,
+    pub inner: Box<Element>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Root {
-    pub(crate) base: Box<Element>,
-    pub(crate) inner: Box<Element>,
+    pub base: Box<Element>,
+    pub inner: Box<Element>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct Integral {
-    pub(crate) top: Option<Box<Element>>,
-    pub(crate) bottom: Option<Box<Element>>,
+    pub top: Option<Box<Element>>,
+    pub bottom: Option<Box<Element>>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub struct OIntegral {
-    pub(crate) top: Option<Box<Element>>,
-    pub(crate) bottom: Option<Box<Element>>,
+    pub top: Option<Box<Element>>,
+    pub bottom: Option<Box<Element>>,
 }
 
 impl Expression {


### PR DESCRIPTION
This pull request changes some structs' fields' visibilities from `pub(crate)` to `pub` (fix #13).

NOTE: See also [Rust API Guidelines > Structs have private fields (C-STRUCT-PRIVATE)](https://rust-lang.github.io/api-guidelines/future-proofing.html?highlight=getter#structs-have-private-fields-c-struct-private) for more information about structures exposing public fields. In other words, I think there is also a way to provide a getter method.